### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '2'
 services:
   web:
     image: ahannigan/docker-arachni
-    build: .
     ports:
       - "9292:9292"
     command: bin/arachni_web -o 0.0.0.0


### PR DESCRIPTION
build not needed when there's already a released image